### PR TITLE
Made Gradle into a link to stay consistent

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -43,7 +43,7 @@ Javadocs are available [here](http://netflix.github.com/netflix-graph/javadoc).
 Build
 -----
 
-NetflixGraph is built via Gradle (www.gradle.org). To build from the command line:
+NetflixGraph is built via [Gradle](www.gradle.org). To build from the command line:
 
     ./gradlew build
 


### PR DESCRIPTION
Gradle was the only link not made into a hyperlink, changed for consistency.
